### PR TITLE
changed @property (with ad-hoc hasattr caching) to instead use memoized-property library

### DIFF
--- a/pyensembl/gene.py
+++ b/pyensembl/gene.py
@@ -68,11 +68,10 @@ class Gene(Locus):
         # We're doing a SQL query for each transcript ID to fetch
         # its particular information, might be more efficient if we
         # just get all the columns here, but how do we keep that modular?
-        transcripts = [
+        return [
             Transcript(result[0], self.db)
             for result in results
         ]
-        self._transcripts = transcripts
 
     @memoized_property
     def exons(self):

--- a/pyensembl/locus.py
+++ b/pyensembl/locus.py
@@ -1,6 +1,4 @@
-
 def normalize_chromosome(c):
-
     if isinstance(c, (int, long)):
         if c == 0:
             raise ValueError("Contig cannot be 0")

--- a/pyensembl/reference_transcripts.py
+++ b/pyensembl/reference_transcripts.py
@@ -23,7 +23,6 @@ class ReferenceTranscripts(object):
             species="homo_sapiens",
             server=ENSEMBL_FTP_SERVER):
 
-        print "MADE A NEW ReferenceTranscripts!"
         # download cache for fetching reference FASTA files
         self.cache = Cache(CACHE_SUBDIR)
 

--- a/pyensembl/reference_transcripts.py
+++ b/pyensembl/reference_transcripts.py
@@ -23,6 +23,7 @@ class ReferenceTranscripts(object):
             species="homo_sapiens",
             server=ENSEMBL_FTP_SERVER):
 
+        print "MADE A NEW ReferenceTranscripts!"
         # download cache for fetching reference FASTA files
         self.cache = Cache(CACHE_SUBDIR)
 
@@ -47,7 +48,15 @@ class ReferenceTranscripts(object):
         # dictionary mapping transcript IDs to cDNA sequences
         self._transcript_sequences = {}
 
+        # pyfaidx Fasta dictionary gets lazily constructed
+        # since we only want to download the Fasta file if/when
+        # we use it
         self._fasta_dictionary = None
+
+        # key set for fasta dictionary, for faster membership tests,
+        # pyfaidx does something upsettingly slow in its __contains__
+        # method, see comment on `transcript_sequence`.
+        self._fasta_keys = None
 
     @property
     def local_fasta_path(self):
@@ -76,10 +85,20 @@ class ReferenceTranscripts(object):
             if not transcript_id.startswith("ENST"):
                 raise ValueError("Invalid transcript ID: %s" % (transcript_id,))
 
-            if transcript_id not in self.fasta_dictionary:
+
+            # the __getitem__ on pyfaidx.Fasta does a list copy and
+            # traversal to check whether the transcript ID is valid,
+            # much faster if by-pass this logic with our own key membershop
+            # check and then construct the FastaRecord ourselves.
+            #
+            # Example speedup: previously 24s, now 3s annotating 311 transcripts
+            #
+            if transcript_id not in self:
                 raise ValueError(
                     "Transcript ID not found: %s" % (transcript_id,))
-            fasta_record = self.fasta_dictionary[transcript_id]
+
+            fasta_record = pyfaidx.FastaRecord(
+                transcript_id, self.fasta_dictionary)
 
             # FastaRecord doesn't seem to have an accessor to get the full
             # sequence (only subsequences), so slice out the full string
@@ -95,4 +114,9 @@ class ReferenceTranscripts(object):
         return str(self)
 
     def __contains__(self, transcript_id):
-        return transcript_id in self.fasta_dictionary
+        # the pyfaidx __contains__ method requires an expensive list traversal
+        # so cache the keys as a set for faster membership checks
+        if self._fasta_keys is None:
+            keys = self.fasta_dictionary.keys()
+            self._fasta_keys = set(keys)
+        return transcript_id in self._fasta_keys

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -1,7 +1,8 @@
-from locus import Locus
 from exon import Exon
+from locus import Locus, normalize_chromosome
 
 from pyfaidx import Sequence
+from memoized_property import memoized_property
 
 class Transcript(Locus):
     """
@@ -29,7 +30,7 @@ class Transcript(Locus):
             'end',
             'strand',
             'gene_name',
-            'gene_id'
+            'gene_id',
         ]
         transcript_name, contig, start, end, strand, gene_name, gene_id = \
             self.db.query_one(
@@ -56,7 +57,6 @@ class Transcript(Locus):
                 "Missing gene ID for transcript with ID = %s" % transcript_id)
         self.gene_id = gene_id
 
-        self._sequence = None
 
     def __str__(self):
         return "Transcript(id=%s, name=%s, gene_name=%s)" % (
@@ -69,46 +69,40 @@ class Transcript(Locus):
         """
         Length of a transcript is the sum of its exon lengths
         """
-        # cache the length once you compute it
-        if not hasattr(self, "_length"):
-            self._length = sum(len(exon) for exon in self.exons)
-        return self._length
+        return len(self.sequence)
 
-    @property
+    @memoized_property
     def exons(self):
-        if not hasattr(self, "_exons"):
-            columns = ['exon_number', 'exon_id']
-            results = self.db.query(
-                columns,
-                filter_column='transcript_id',
-                filter_value=self.id,
-                feature='exon')
+        columns = ['exon_number', 'exon_id']
+        results = self.db.query(
+            columns,
+            filter_column='transcript_id',
+            filter_value=self.id,
+            feature='exon')
 
-             # fill this list in its correct order (by exon_number) by using
-             # the exon_number as a 1-based list offset
-            exons = [None] * len(results)
+         # fill this list in its correct order (by exon_number) by using
+         # the exon_number as a 1-based list offset
+        exons = [None] * len(results)
 
-            for entry in results:
-                exon_number, exon_id = entry
+        for entry in results:
+            exon_number, exon_id = entry
 
-                exon = Exon(exon_id, self.db)
-                exon_number = int(exon_number)
-                assert exon_number >= 1, "Invalid exon number: %s" % exon_number
-                assert exon_number <= len(exons), \
-                    "Invalid exon number: %s (max expected = %d)" % (
-                        exon_number, len(exons))
+            exon = Exon(exon_id, self.db)
+            exon_number = int(exon_number)
+            assert exon_number >= 1, "Invalid exon number: %s" % exon_number
+            assert exon_number <= len(exons), \
+                "Invalid exon number: %s (max expected = %d)" % (
+                    exon_number, len(exons))
 
-                # exon_number is 1-based, convert to list index by subtracting 1
-                exons[exon_number - 1] = exon
-            assert all(exon is not None for exon in exons), \
-                "Missing exons %s for transcript %s" % (
-                    [i for i, exon in enumerate(exons) if exon is None],
-                    self.transcript_name
-                )
-            self._exons = exons
+            # exon_number is 1-based, convert to list index by subtracting 1
+            exons[exon_number - 1] = exon
 
-        return self._exons
-
+        assert all(exon is not None for exon in exons), \
+            "Missing exons %s for transcript %s" % (
+                [i for i, exon in enumerate(exons) if exon is None],
+                self.transcript_name
+            )
+        return exons
 
     # possible annotations associated with transcripts
     _TRANSCRIPT_FEATURES = {'start_codon', 'stop_codon', 'UTR', 'CDS'}
@@ -172,32 +166,32 @@ class Transcript(Locus):
                     len(results)))
         return results
 
-    @property
+    @memoized_property
     def contains_start_codon(self):
         """
         Does this transcript have an annotated start_codon entry in Ensembl?
         """
-        start_codons = _transcript_feature_position_ranges(
+        start_codons = self._transcript_feature_position_ranges(
             'start_codon', required=False)
         return len(start_codons) > 0
 
-    @property
+    @memoized_property
     def contains_stop_codon(self):
         """
         Does this transcript have an annotated stop_codon entry in Ensembl?
         """
-        stop_codons = _transcript_feature_position_ranges(
+        stop_codons = self._transcript_feature_position_ranges(
             'stop_codon', required=False)
         return len(stop_codons) > 0
 
-    @property
+    @memoized_property
     def start_codon_positions(self):
         """
         Chromosomal positions of nucleotides in start codon.
         """
         return self._codon_positions('start_codon')
 
-    @property
+    @memoized_property
     def stop_codon_positions(self):
         """
         Chromosomal positions of nucleotides in stop codon.
@@ -257,9 +251,7 @@ class Transcript(Locus):
             "Couldn't find position %d on any exon of %s" % (
                 position, self.id))
 
-
-
-    @property
+    @memoized_property
     def start_codon_unspliced_offsets(self):
         """
         Offsets from start of unspliced pre-mRNA transcript
@@ -271,7 +263,7 @@ class Transcript(Locus):
             in self.start_codon_positions
         ]
 
-    @property
+    @memoized_property
     def stop_codon_unspliced_offsets(self):
         """
         Offsets from start of unspliced pre-mRNA transcript
@@ -294,7 +286,7 @@ class Transcript(Locus):
                 "Offsets not contiguous: %s" % (offsets,)
         return offsets
 
-    @property
+    @memoized_property
     def start_codon_spliced_offsets(self):
         """
         Offsets from start of spliced mRNA transcript
@@ -307,7 +299,7 @@ class Transcript(Locus):
         ]
         return self._contiguous_offsets(offsets)
 
-    @property
+    @memoized_property
     def stop_codon_spliced_offsets(self):
         """
         Offsets from start of spliced mRNA transcript
@@ -320,7 +312,7 @@ class Transcript(Locus):
         ]
         return self._contiguous_offsets(offsets)
 
-    @property
+    @memoized_property
     def coding_sequence_position_ranges(self):
         """
         Return absolute chromosome position ranges for CDS fragments
@@ -328,17 +320,7 @@ class Transcript(Locus):
         """
         return self._transcript_feature_position_ranges('CDS')
 
-    @property
-    def coding_sequence_length(self):
-        total = 0
-        for (start, stop) in self.coding_sequence_position_ranges:
-            assert start <= stop, \
-                "Invalid offset range [%d..%d] for transcript %s" % (
-                    start, stop, self.id)
-            total += stop - start + 1
-        return total
-
-    @property
+    @memoized_property
     def complete(self):
         """
         Consider a transcript complete if it has start and stop codons and
@@ -347,26 +329,26 @@ class Transcript(Locus):
         return (
             self.contains_start_codon and
             self.contains_stop_codon and
-            self.coding_sequence_length % 3 == 0
+            len(self.coding_sequence) % 3 == 0
         )
 
-    @property
+    @memoized_property
     def sequence(self):
         """
         Spliced cDNA sequence of transcript
         (includes 5' UTR, coding sequence, and 3' UTR)
         """
-        if self._sequence is None:
-            if self.id not in self.reference:
-                raise ValueError(
-                    "No sequence for transcript %s in reference %s" % (
-                        self.id, self.reference))
+        print "sequence?"
+        try:
             # fetch this transcript's Sequence from the attached
             # ReferenceTranscripts object
-            self._sequence = self.reference.transcript_sequence(self.id)
-        return self._sequence
+            return self.reference.transcript_sequence(self.id)
+        except KeyError:
+            raise ValueError(
+                "No sequence for transcript %s in reference %s" % (
+                    self.id, self.reference))
 
-    @property
+    @memoized_property
     def first_start_codon_spliced_offset(self):
         """
         Offset of first nucleotide in start codon into the spliced mRNA
@@ -375,8 +357,7 @@ class Transcript(Locus):
         start_offsets = self.start_codon_spliced_offsets
         return min(start_offsets)
 
-
-    @property
+    @memoized_property
     def last_stop_codon_spliced_offset(self):
         """
         Offset of last nucleotide in stop codon into the spliced mRNA
@@ -385,8 +366,7 @@ class Transcript(Locus):
         stop_offsets = self.stop_codon_spliced_offsets
         return max(stop_offsets)
 
-
-    @property
+    @memoized_property
     def coding_sequence(self):
         """
         cDNA coding sequence (from start codon to stop codon, without
@@ -401,7 +381,7 @@ class Transcript(Locus):
         # Adding 1 to end since Python uses non-inclusive ends in slices/ranges.
         return self.sequence[start:end+1]
 
-    @property
+    @memoized_property
     def five_prime_utr_sequence(self):
         """
         cDNA sequence of 5' UTR
@@ -409,7 +389,7 @@ class Transcript(Locus):
         """
         return self.sequence[:self.first_start_codon_spliced_offset]
 
-    @property
+    @memoized_property
     def three_prime_utr_sequence(self):
         """
         cDNA sequence of 3' UTR

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -84,9 +84,7 @@ class Transcript(Locus):
          # the exon_number as a 1-based list offset
         exons = [None] * len(results)
 
-        for entry in results:
-            exon_number, exon_id = entry
-
+        for exon_number, exon_id in results:
             exon = Exon(exon_id, self.db)
             exon_number = int(exon_number)
             assert exon_number >= 1, "Invalid exon number: %s" % exon_number

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -338,7 +338,6 @@ class Transcript(Locus):
         Spliced cDNA sequence of transcript
         (includes 5' UTR, coding sequence, and 3' UTR)
         """
-        print "sequence?"
         try:
             # fetch this transcript's Sequence from the attached
             # ReferenceTranscripts object

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 if __name__ == '__main__':
     setup(
         name='pyensembl',
-        version="0.5.1",
+        version="0.5.2",
         description="Python interface to ensembl reference genome metadata",
       	author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",
@@ -51,6 +51,7 @@ if __name__ == '__main__':
             'pandas>=0.13.1',
             'datacache>=0.4.2',
 	    'pyfaidx',
+	    'memoized-property',
         ],
         long_description=readme,
         packages=['pyensembl'],


### PR DESCRIPTION
Fixes https://github.com/hammerlab/pyensembl/issues/23

Also:
* check validity of gene_biotype on Gene object
* sped up `__contains__` and sequence access on `ReferenceTranscripts` by by-passing `pyfaidx.Fasta.__contains__` (which copies a list of keys every time) 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pyensembl/26)
<!-- Reviewable:end -->
