### PR TITLE
Make downloads explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,20 @@ pip install pyensembl
 This should also install any required packages, such as [datacache](https://github.com/hammerlab/datacache) and
 [pyfaidx](https://pypi.python.org/pypi/pyfaidx).
 
-The first time you use PyEnsembl, there will be a delay of several minutes while the library downloads and parses Ensembl data files.
+Before using PyEnsembl, run the following command to download and install
+Ensembl data:
 
+```
+pyensembl <list of Ensembl release numbers> install
+```
+
+For example, `pyensembl 75 76 install` will download and install all
+data for Ensembl releases 75 and 76.
+
+Alternatively, you can create the `EnsemblRelease` object with
+`auto_download=True`. PyEnsembl will then download your data as you
+need it, and there will be a delay of several minutes after your first
+command.
 
 # API
 

--- a/pyensembl/shell.py
+++ b/pyensembl/shell.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""
+A shell wrapper around various PyEnsembl commands.
+
+Example:
+
+pyensembl 75 77 install
+"""
+import argparse
+
+import ensembl_release
+from release_info import MAX_ENSEMBL_RELEASE
+
+
+def run():
+    parser = argparse.ArgumentParser(usage=__doc__)
+    parser.add_argument(
+        'release',
+        nargs='*',
+        default=MAX_ENSEMBL_RELEASE,
+        help=('specify the Ensembl release(s) that you would like to '
+              'download and install (defaults to latest release)'))
+    subparsers = parser.add_subparsers(dest='program')
+    subparsers.add_parser(
+        'install',
+        help=('download and index any data for this release that '
+               'is not yet downloaded and/or indexed'))
+    subparsers.add_parser(
+        'download',
+        help=('download all data for this release, regardless of '
+              'whether it is already downloaded'))
+    subparsers.add_parser(
+        'index',
+        help=('index all data for this release, regardless of '
+              'whether it is already indexed, and raises an error if '
+              'data is not yet downloaded'))
+
+    args = parser.parse_args()
+    releases = args.release
+    if type(releases) == int:
+        releases = [releases]
+    for release in releases:
+        data = ensembl_release.EnsemblRelease(release)
+        if args.program == 'install':
+            data.install()
+        elif args.program == 'download':
+            data.download()
+        elif args.program == 'index':
+            data.index()
+
+
+if __name__ == '__main__':
+    run()

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -2,9 +2,8 @@ from __future__ import print_function, division, absolute_import
 
 from .biotypes import is_valid_biotype
 from .exon import Exon
-from .locus import Locus, normalize_chromosome
+from .locus import Locus
 
-from pyfaidx import Sequence
 from memoized_property import memoized_property
 from .type_checks import require_integer, require_string
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy==1.7
+pandas==0.13.1
+datacache==0.4.5
+pyfaidx==0.3.4
+memoized-property==1.0.2
+nose2==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,17 @@ from setuptools import setup
 if __name__ == '__main__':
     setup(
         name='pyensembl',
-        version="0.5.4",
+        version="0.5.5",
         description="Python interface to ensembl reference genome metadata",
       	author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",
       	url="https://github.com/hammerlab/pyensembl",
         license="http://www.apache.org/licenses/LICENSE-2.0.html",
+        entry_points={
+          'console_scripts': [
+              'pyensembl = pyensembl.shell:run'
+          ],
+        },
         classifiers=[
             'Development Status :: 3 - Alpha',
             'Environment :: Console',
@@ -49,9 +54,9 @@ if __name__ == '__main__':
         install_requires=[
             'numpy>=1.7',
             'pandas>=0.13.1',
-            'datacache>=0.4.2',
-	    'pyfaidx',
-	    'memoized-property',
+            'datacache>=0.4.6',
+            'pyfaidx>=0.3.4',
+            'memoized-property>=1.0.2',
         ],
         long_description=readme,
         packages=['pyensembl'],

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -14,7 +14,7 @@ _cached_releases = {}
 def cached_release(version):
     if version in _cached_releases:
         return _cached_releases[version]
-    ensembl = EnsemblRelease(version)
+    ensembl = EnsemblRelease(version, auto_download=True)
     _cached_releases[version] = ensembl
     return ensembl
 

--- a/test/test_compute_cache.py
+++ b/test/test_compute_cache.py
@@ -1,5 +1,3 @@
-from os import remove
-from os.path import exists
 import tempfile
 
 from pyensembl import compute_cache

--- a/test/test_dataframe_release75.py
+++ b/test/test_dataframe_release75.py
@@ -1,6 +1,6 @@
 from pyensembl import EnsemblRelease
 
-ensembl = EnsemblRelease(75)
+ensembl = EnsemblRelease(75, auto_download=True)
 
 def test_release_75_length():
     df = ensembl.gtf.dataframe()

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -1,0 +1,84 @@
+from mock import Mock, patch
+from nose.tools import assert_raises
+
+from pyensembl import EnsemblRelease
+
+
+@patch('pyensembl.reference_transcripts.ReferenceTranscripts.local_fasta_path')
+@patch('pyensembl.reference_transcripts.exists')
+@patch('pyensembl.reference_transcripts.pyfaidx')
+def _test_fai_index(mock_pyfaidx, mock_exists, mock_local_fasta_path,
+                    fai_exists, force_index):
+    """
+    Depending on whether we already have a .fai file created by
+    pyfaidx, and whether we're using the force flag for
+    EnsemblRelease(...)._index, we may or may not expect write_fai
+    to be called.
+
+    Return True if it was called.
+    """
+    data = EnsemblRelease(54)
+
+    # Skip the GTF stuff, since we're testing pyfaidx
+    data.db._connect_if_exists = Mock(return_value=False)
+    data.db._create_database = Mock()
+
+    mock_exists.return_value = fai_exists
+    data._index(force=force_index)
+
+    return mock_pyfaidx.Fasta().faidx.write_fai.called
+
+
+def test_fai_exists_index():
+    called = _test_fai_index(fai_exists=True, force_index=False)
+    assert not called, 'Expected no new .fai file'
+
+
+def test_fai_not_exists_index():
+    called = _test_fai_index(fai_exists=False, force_index=False)
+    assert called, 'Expected a new .fai file'
+
+
+def test_fai_exists_force_index():
+    called = _test_fai_index(fai_exists=True, force_index=True)
+    assert called, 'Expected a new .fai file'
+
+
+def test_fai_not_exists_force_index():
+    called = _test_fai_index(fai_exists=False, force_index=True)
+    assert called, 'Expected a new .fai file'
+
+
+@patch('pyensembl.reference_transcripts.ReferenceTranscripts.index')
+def _test_db_index(mock_index, db_exists):
+    """
+    Return True if the GTF database gets created, which should
+    be different depending on whether the database already existed.
+
+    Note: we need to mock the reference transcript indexing, as we're
+    testing GTF indexing.
+    """
+    data = EnsemblRelease(54)
+    data.db._connect_if_exists = Mock(return_value=db_exists)
+    data.db._create_database = Mock()
+
+    data._index(force=False)
+
+    return data.db._create_database.called
+
+
+def test_db_not_exists_index():
+    called = _test_db_index(db_exists=False)
+    assert called, "Expected a new database"
+
+
+def test_db_exists_index():
+    called = _test_db_index(db_exists=True)
+    assert not called, "Expected no new database"
+
+
+def test_auto_download_off():
+    data = EnsemblRelease(54)
+    data.db._connect_if_exists = Mock(return_value=False)
+    assert_raises(ValueError, data.gene_names_at_locus,
+        contig=6, position=29945884)

--- a/test/test_exon_id.py
+++ b/test/test_exon_id.py
@@ -5,7 +5,7 @@ from the Ensembl website, make sure same IDs are found by pyensembl.
 
 from pyensembl import EnsemblRelease
 
-ensembl = EnsemblRelease(77)
+ensembl = EnsemblRelease(77, auto_download=True)
 
 # all exons associated with TP53 gene in Ensembl release 77
 TP53_EXON_IDS_RELEASE_77 = [

--- a/test/test_exon_object.py
+++ b/test/test_exon_object.py
@@ -6,9 +6,7 @@ the expected gene ID and location.
 
 from pyensembl import EnsemblRelease
 
-from test_common import releases
-
-ensembl77 = EnsemblRelease(77)
+ensembl77 = EnsemblRelease(77, auto_download=True)
 
 def test_exon_object_by_id():
     """

--- a/test/test_gene_id.py
+++ b/test/test_gene_id.py
@@ -2,7 +2,7 @@ from pyensembl import EnsemblRelease
 
 from nose.tools import assert_raises
 
-ensembl = EnsemblRelease(77)
+ensembl = EnsemblRelease(77, auto_download=True)
 
 def test_gene_ids_of_gene_name_hla_release77():
     hla_a_gene_ids = ensembl.gene_ids_of_gene_name("HLA-A")

--- a/test/test_gene_ids.py
+++ b/test/test_gene_ids.py
@@ -13,7 +13,8 @@ def test_gene_ids_ensembl77_hla_a():
     # based on:
     # http://useast.ensembl.org/Homo_sapiens/Gene/
     # Summary?db=core;g=ENSG00000206503;r=6:29941260-29945884
-    ids = EnsemblRelease(77).gene_ids_at_locus(6, 29945884)
+    ids = (EnsemblRelease(77, auto_download=True).
+           gene_ids_at_locus(6, 29945884))
     expected = "ENSG00000206503"
     assert ids == ["ENSG00000206503"], \
         "Expected HLA-A, gene ID = %s, got: %s" % (expected, ids)

--- a/test/test_gene_names.py
+++ b/test/test_gene_names.py
@@ -32,7 +32,8 @@ def test_gene_names_at_locus_ensembl77_hla_a():
     # based on:
     # http://useast.ensembl.org/Homo_sapiens/Gene/
     # Summary?db=core;g=ENSG00000206503;r=6:29941260-29945884
-    names = EnsemblRelease(77).gene_names_at_locus(6, 29945884)
+    names = (EnsemblRelease(77, auto_download=True).
+             gene_names_at_locus(6, 29945884))
     assert names == ["HLA-A"], "Expected gene name HLA-A, got: %s" % (names,)
 
 @test_ensembl_releases()

--- a/test/test_reference_transcripts.py
+++ b/test/test_reference_transcripts.py
@@ -17,7 +17,8 @@ def test_reference_name():
     assert reference77.reference_name == "GRCh38"
 
 def test_transcript_sequence_ensembl54():
-    reference54 = EnsemblRelease(release=54).reference
+    reference54 = EnsemblRelease(release=54,
+                                 auto_download=True).reference
     seq = reference54.transcript_sequence("ENST00000321606")
     assert len(seq) == 414, \
         "Expected transcript ENST00000321606 to have 414nt, got %s : %d" % (

--- a/test/test_release_versions.py
+++ b/test/test_release_versions.py
@@ -1,5 +1,3 @@
-from os.path import exists
-
 from pyensembl import EnsemblRelease
 
 from nose.tools import raises
@@ -23,8 +21,8 @@ def test_version_is_none():
 
 def test_int_version():
     for version in range(54, 77):
-        ensembl = EnsemblRelease(version)
+        EnsemblRelease(version)
 
 def test_str_version():
     for version in range(54, 77):
-        ensembl = EnsemblRelease(str(version))
+        EnsemblRelease(str(version))

--- a/test/test_transcript_ids.py
+++ b/test/test_transcript_ids.py
@@ -24,7 +24,7 @@ def test_transcript_ids_ensembl77_hla_a():
     # based on:
     # http://useast.ensembl.org/Homo_sapiens/Gene/
     # Summary?db=core;g=ENSG00000206503;r=6:29941260-29945884
-    ensembl = EnsemblRelease(77)
+    ensembl = EnsemblRelease(77, auto_download=True)
     transcript_ids = ensembl.transcript_ids_at_locus(6, 29941260, 29945884)
     for transcript_id in HLA_A_TRANSCRIPT_IDS:
         assert transcript_id in transcript_ids, \

--- a/test/test_transcript_ids_at_locus.py
+++ b/test/test_transcript_ids_at_locus.py
@@ -1,6 +1,6 @@
 from pyensembl import EnsemblRelease
 
-ensembl = EnsemblRelease(77)
+ensembl = EnsemblRelease(77, auto_download=True)
 # chr6:29,945,884  is a position for HLA-A
 # based on:
 # http://useast.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000206503;r=6:29941260-29945884


### PR DESCRIPTION
Make downloads explicit (unless `auto_download` is `True`). An Exception is raised if the necessary data isn't present, and users can either use the shell or python to run the downloads. Fixes #31 

Relies on https://github.com/hammerlab/datacache/pull/7

A few questions that come to mind:

- Did I hook into the right places?
- Do you think the `varcode` should also have an `auto_download` flag to send along to `pyensembl`?

TODO:

- Tests
- README update

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pyensembl/34)
<!-- Reviewable:end -->
