### PR TITLE
added Timer class and benchmark unit tests

### DIFF
--- a/test/test_timings.py
+++ b/test/test_timings.py
@@ -1,0 +1,58 @@
+from __future__ import print_function
+
+from pyensembl import EnsemblRelease
+from timer import benchmark
+
+ensembl = EnsemblRelease(78)
+contigs = [str(i+1) for i in range(22)] + ["X", "Y"]
+
+def make_repeat_lookup_fn(lookup_fn, n_positions):
+    """
+    Make a thunk which calls the lookup_fn at a number of loci
+    for each human chromosome (excluding MT).
+    """
+    def repeat_lookup_fn():
+        for contig in contigs:
+            for position in [10**6 + i*10**6 for i in range(n_positions)]:
+                lookup_fn(contig, position)
+    return repeat_lookup_fn
+
+def run_benchmark(lookup_fn, n_positions_per_contig=20, time_limit=60.0):
+    """
+    Take a lookup functions (such as EnsemblRelease.genes_at_locus) and
+    time how long it takes across multiple loci.
+    """
+    repeat_lookup_fn = make_repeat_lookup_fn(lookup_fn, n_positions_per_contig)
+    n_loci = n_positions_per_contig * len(contigs)
+    name = lookup_fn.__name__
+    average_time = benchmark(
+        repeat_lookup_fn,
+        name="%s for %d loci" % (name, n_loci))
+    print("-- %s : %0.4fs" % (name, average_time))
+    assert average_time < time_limit, \
+        "%s took too long for %s loci: %0.4fs" % (name, n_loci, average_time)
+    return average_time
+
+def test_timing_genes_at_locus():
+    run_benchmark(ensembl.genes_at_locus)
+
+def test_timing_transcripts_at_locus():
+    run_benchmark(ensembl.transcripts_at_locus)
+
+def test_timing_exons_at_locus():
+    run_benchmark(ensembl.exons_at_locus)
+
+
+def run_all_benchmarks():
+    import types
+
+    # run all local test functions to see their timings printed
+    global_variables = globals()
+    for variable_name in global_variables:
+        if "test_" in variable_name:
+            f = global_variables[variable_name]
+            if isinstance(f, types.FunctionType):
+                f()
+
+if __name__ == "__main__":
+    run_all_benchmarks()

--- a/test/timer.py
+++ b/test/timer.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+
+import time
+
+class Timer(object):
+    """
+    Time context for benchmarking
+    """
+    def __init__(self, name=""):
+        self.name = name
+        self._start = None
+        self._end = None
+
+    def start(self):
+        self._start = time.time()
+        self._end = self._start
+
+    def stop(self):
+        self._end = time.time()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *args):
+        self.stop()
+        if self.name:
+            print("%s : %0.3f seconds" % (self.name, self.elapsed))
+
+    @property
+    def elapsed(self):
+        return self._end - self._start
+
+    def __str__(self):
+        return "Timer(elapsed=%s)" % self.elapsed
+
+def benchmark(f, n_repeats=3, warmup=True, name=""):
+    """
+    Run the given function f repeatedly, return the average elapsed time.
+    """
+    if warmup:
+        f()
+
+    total_time = 0
+    for i in range(n_repeats):
+        iter_name = "%s (iter #%d)" % (name, i+1,)
+        with Timer(iter_name) as t:
+            f()
+        total_time += t.elapsed
+    return total_time / n_repeats

--- a/test/timer.py
+++ b/test/timer.py
@@ -29,7 +29,11 @@ class Timer(object):
 
     @property
     def elapsed(self):
-        return self._end - self._start
+        if self._end is None:
+            end_time = time.time()
+        else:
+            end_time = self_end
+        return end_time - self._start
 
     def __str__(self):
         return "Timer(elapsed=%s)" % self.elapsed


### PR DESCRIPTION

Currently only testing performance of  `genes_at_locus`, `transcripts_at_locus`, `exons_at_locus` but should be easy to add more later. Also, there's a hackish search through the globals dict to find all benchmarks when they're being run outside of nose. If we need to reuse that trick elsewhere, I'll factor it out into its own module. 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pyensembl/48)
<!-- Reviewable:end -->
