### PR TITLE
Cleanup pyensembl commandline utility

### DIFF
--- a/pyensembl/database.py
+++ b/pyensembl/database.py
@@ -217,10 +217,10 @@ class Database(object):
             return connection
         if self.auto_download:
             return self._create_database()
-        raise ValueError("Genome annotation data is not currently "
-                         "installed for release %s. Run "
-                         "\"pyensembl install %s\" or call "
-                         "EnsemblRelease(%s).install()" %
+        raise ValueError('Genome annotation data is not currently '
+                         'installed for release %s. Run '
+                         '"pyensembl install --release %s" or call '
+                         '"EnsemblRelease(%s).install()"' %
                          ((self.gtf.release,) * 3))
 
     def columns(self, table_name):

--- a/pyensembl/gtf.py
+++ b/pyensembl/gtf.py
@@ -108,10 +108,10 @@ class GTF(object):
                 self.url,
                 self.local_filename(),
                 decompress=self.decompress)
-        raise ValueError("Ensembl annotation data is not currently "
-                         "installed for release %s. Run "
-                         "\"pyensembl install %s\" or call "
-                         "EnsemblRelease(%s).install()" %
+        raise ValueError('Ensembl annotation data is not currently '
+                         'installed for release %s. Run '
+                         '"pyensembl install --release %s" or call '
+                         '"EnsemblRelease(%s).install()"' %
                          ((self.release,) * 3))
 
     def local_dir(self):

--- a/pyensembl/shell.py
+++ b/pyensembl/shell.py
@@ -15,54 +15,48 @@
 # limitations under the License.
 
 """
-A shell wrapper around various PyEnsembl commands.
+Manipulate pyensembl's local cache.
 
-Example:
+    %(prog)s {install,download,index} [--release XXX ...]
 
-    pyensembl 75 77 install
+To install the latest ensembl release:
+    %(prog)s install
+
+To install particular release(s):
+    %(prog)s install --release 75 77
+
 """
+from __future__ import absolute_import
 import argparse
-
-import ensembl_release
-from release_info import MAX_ENSEMBL_RELEASE
-
+from . import ensembl_release
+from .release_info import MAX_ENSEMBL_RELEASE
 
 def run():
     parser = argparse.ArgumentParser(usage=__doc__)
-    parser.add_argument(
-        'release',
-        nargs='*',
-        default=MAX_ENSEMBL_RELEASE,
-        help=('specify the Ensembl release(s) that you would like to '
-              'download and install (defaults to latest release)'))
-    subparsers = parser.add_subparsers(dest='program')
-    subparsers.add_parser(
-        'install',
-        help=('download and index any data for this release that '
-               'is not yet downloaded and/or indexed'))
-    subparsers.add_parser(
-        'download',
-        help=('download all data for this release, regardless of '
-              'whether it is already downloaded'))
-    subparsers.add_parser(
-        'index',
-        help=('index all data for this release, regardless of '
-              'whether it is already indexed, and raises an error if '
-              'data is not yet downloaded'))
+    parser.add_argument('--release',
+        type=int,
+        nargs="+",
+        default=[MAX_ENSEMBL_RELEASE],
+        help='Ensembl release. Defaults to latest release %(default)s. '
+             'Multiple releases may be specified.')
+    parser.add_argument('action', choices=('install', 'download', 'index'),
+        help="'install' will download and index any data that is  not "
+        "currently downloaded or indexed. 'download' will download data, "
+        "regardless of whether it is already downloaded. 'index' will index "
+        "data, regardless of whether it is already indexed, and will raise "
+        "an error if the data is not already downloaded.")
 
     args = parser.parse_args()
-    releases = args.release
-    if type(releases) == int:
-        releases = [releases]
-    for release in releases:
-        data = ensembl_release.EnsemblRelease(release)
-        if args.program == 'install':
-            data.install()
-        elif args.program == 'download':
-            data.download()
-        elif args.program == 'index':
-            data.index()
-
+    for release in args.release:
+        ensembl = ensembl_release.EnsemblRelease(release)
+        if args.action == 'install':
+            ensembl.install()
+        elif args.action == 'download':
+            ensembl.download()
+        elif args.action == 'index':
+            ensembl.index()
+        else:
+            assert False, "shouldn't get here"
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
 * `pyensembl` commandline utility now works in Python 3.
 * more intuitive syntax, better help.
 * fix error messages elsewhere to give correct pyensembl command to run to install ensembl release data.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pyensembl/61)
<!-- Reviewable:end -->
