### PR TITLE
Fix release 79

### DIFF
--- a/pyensembl/biotypes.py
+++ b/pyensembl/biotypes.py
@@ -220,6 +220,13 @@ non_immune_protein_coding = {
     # usually a non-coding pseudogene but can be translated in some individuals
     # depending on common genetic variation
     'polymorphic_pseudogene',
+    # Otherwise viable coding region omitted from this alternatively spliced
+    # transcript because the splice variation affects a region coding for a
+    # protein domain.
+    'disrupted_domain',
+    # Gene in a "Locus Reference Genomic" region known to have disease-related
+    # sequence variations.
+    'LRG_gene',
 }
 
 protein_coding = set.union(
@@ -251,7 +258,9 @@ coding_pseudogenes = {
     # to be experimentally confirmed
     'TEC',
     # TODO: should this be here or considered protein_coding?
-    'translated_unprocessed_pseudogene'
+    'translated_unprocessed_pseudogene',
+    # pseudogene owing to a reverse transcribed and re-inserted sequence.
+    "retrotransposed",
 }
 
 long_noncoding = {
@@ -268,7 +277,9 @@ long_noncoding = {
     'retained_intron',
     'sense_intronic',
     'sense_overlapping',
-    'known_ncrna'
+    'known_ncrna',
+    # unspliced lncRNAs that are several kb in size.
+    'macro_lncRNA',
 }
 
 mitochondrial = {
@@ -301,6 +312,11 @@ short_noncoding_functional = {
     'snoRNA',
     'snRNA',
     'tRNA',
+    # Small Cajal body-specific RNA
+    'scaRNA',
+    # Vault RNA (http://en.wikipedia.org/wiki/Vault_RNA)
+    'vaultRNA',
+    'ribozyme',
 }
 
 short_noncoding = set.union(
@@ -313,6 +329,8 @@ valid_biotypes = set.union(
     coding_pseudogenes,
     long_noncoding,
     short_noncoding,
+    # used to tag mistakes in the annotation database
+    {"artifact"},
 )
 
 def is_valid_biotype(biotype):

--- a/pyensembl/biotypes.py
+++ b/pyensembl/biotypes.py
@@ -312,6 +312,7 @@ short_noncoding_functional = {
     'snoRNA',
     'snRNA',
     'tRNA',
+    'sRNA',
     # Small Cajal body-specific RNA
     'scaRNA',
     # Vault RNA (http://en.wikipedia.org/wiki/Vault_RNA)

--- a/pyensembl/gtf.py
+++ b/pyensembl/gtf.py
@@ -285,9 +285,11 @@ class GTF(object):
         Returns only ENSG00000000003, since it overlaps
         [100000000, 110000000].
         """
-        df = pd.DataFrame({'name': column_name_series,
-                           'start': start_series,
-                           'end': end_series})
+        df = pd.DataFrame({
+            'name': column_name_series,
+            'start': start_series,
+            'end': end_series
+        })
         df = GTF._slice(df, 'start', 'end', start, end)
         return df.name
 
@@ -335,12 +337,9 @@ class GTF(object):
 
         Returns True if a download happened.
         """
-        if not force and self.local_copy_exists():
-            return False
-
-        self.cache.fetch(
-            self.url,
-            self.local_filename(),
-            decompress=self.decompress,
-            force=force)
-        return True
+        if not self.local_copy_exists() or force:
+            self.cache.fetch(
+                self.url,
+                self.local_filename(),
+                decompress=self.decompress,
+                force=force)

--- a/pyensembl/gtf.py
+++ b/pyensembl/gtf.py
@@ -334,8 +334,6 @@ class GTF(object):
         """
         Download the GTF file if one does not exist. If `force` is
         True, overwrites any existing file.
-
-        Returns True if a download happened.
         """
         if not self.local_copy_exists() or force:
             self.cache.fetch(

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -52,9 +52,6 @@ class Transcript(Locus):
         self.db = ensembl.db
         require_instance(self.db, Database, "db")
 
-        self.transcript_sequences = ensembl.transcript_sequences
-        self.protein_sequences = ensembl.protein_sequences
-
         columns = [
             'transcript_name',
             'transcript_biotype',
@@ -404,7 +401,7 @@ class Transcript(Locus):
         Spliced cDNA sequence of transcript
         (includes 5' UTR, coding sequence, and 3' UTR)
         """
-        return self.transcript_sequences.get(self.id)
+        return self.ensembl.transcript_sequences.get(self.id)
 
     @memoized_property
     def first_start_codon_spliced_offset(self):

--- a/pyensembl/url_templates.py
+++ b/pyensembl/url_templates.py
@@ -168,7 +168,7 @@ def fasta_url(
             "Species": species.capitalize(),
             "reference": reference_name,
             "release": ensembl_release,
-            "sequence_type": "cdna",
+            "sequence_type": sequence_type,
         }
     else:
         filename = NEW_FASTA_FILENAME_TEMPLATE % {

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError as e:
 if __name__ == '__main__':
     setup(
         name='pyensembl',
-        version="0.6.1",
+        version="0.6.2",
         description="Python interface to ensembl reference genome metadata",
         author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",


### PR DESCRIPTION
* Ensembl 79's GTF added another surprise: entries in the last column with multiple spaces. This isn't really their fault, since the spaces were within quotes. Added a bandaid fix, but need to implement a real parser before Ensembl 80 comes out. 

* Added some missing biotypes. 

* PEP8 fixes in `gtf_parsing`

* Fixed FASTA path for protein sequences for Ensembl releases <= 75

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pyensembl/81)
<!-- Reviewable:end -->
