### PR TITLE
 Routing Exon and Transcript construction through memoized methods

### DIFF
--- a/pyensembl/common.py
+++ b/pyensembl/common.py
@@ -19,11 +19,15 @@ from typechecks import is_string
 CACHE_SUBDIR = "ensembl"
 
 def _memoize_cache_key(args, kwargs):
-    """Turn args tuple and kwargs dictionary into a hashable key"""
+    """Turn args tuple and kwargs dictionary into a hashable key.
+
+    Expects that all arguments to a memoized function are either hashable
+    or can be uniquely identified from type(arg) and repr(arg).
+    """
     cache_key = args + tuple(sorted(kwargs.items()))
 
     try:
-        # if any element of the cache isn't hashable then we switch
+        # if any element of the cache key isn't hashable then we switch
         # to using the types and string representations of
         # all the elements in the cache key
         hash(cache_key)

--- a/pyensembl/database.py
+++ b/pyensembl/database.py
@@ -289,7 +289,7 @@ class Database(object):
         query = """
             SELECT %s%s
             FROM %s
-            WHERE seqname= ?
+            WHERE seqname = ?
             AND start <= ?
             AND end >= ?
 

--- a/pyensembl/ensembl_release.py
+++ b/pyensembl/ensembl_release.py
@@ -133,7 +133,7 @@ class EnsemblRelease(object):
         for maybe_fn in self.__dict__.values():
             # clear cache associated with all memoization decorators,
             # GTF and SequenceData objects
-            if hasattr(maybe_fn, 'clear_cache'):
+            if hasattr(maybe_fn, "clear_cache"):
                 maybe_fn.clear_cache()
 
         self._delete_cached_files()
@@ -166,7 +166,7 @@ class EnsemblRelease(object):
             Restrict query to particular contig
 
         strand : str, optional
-            Restrict results to '+' or '-' strands
+            Restrict results to "+" or "-" strands
 
         Returns a list constructed from query results.
         """
@@ -220,14 +220,14 @@ class EnsemblRelease(object):
 
     def transcript_sequence(self, transcript_id):
         """Return cDNA nucleotide sequence of transcript, or None if
-        transcript doesn't cDNA sequence.
+        transcript doesn't have cDNA sequence.
         """
         require_human_transcript_id(transcript_id)
         return self.transcript_sequences.get(transcript_id)
 
     def protein_sequence(self, protein_id):
         """Return cDNA nucleotide sequence of transcript, or None if
-        transcript doesn't cDNA sequence.
+        transcript doesn't have cDNA sequence.
         """
         require_human_protein_id(protein_id)
         return self.protein_sequences.get(protein_id)
@@ -268,8 +268,8 @@ class EnsemblRelease(object):
 
     def gene_ids_at_locus(self, contig, position, end=None, strand=None):
         return self.db.distinct_column_values_at_locus(
-            column='gene_id',
-            feature='gene',
+            column="gene_id",
+            feature="gene",
             contig=contig,
             position=position,
             end=end,
@@ -277,8 +277,8 @@ class EnsemblRelease(object):
 
     def gene_names_at_locus(self, contig, position, end=None, strand=None):
         return self.db.distinct_column_values_at_locus(
-             column='gene_name',
-             feature='gene',
+             column="gene_name",
+             feature="gene",
              contig=contig,
              position=position,
              end=end,
@@ -286,8 +286,8 @@ class EnsemblRelease(object):
 
     def exon_ids_at_locus(self, contig, position, end=None, strand=None):
         return self.db.distinct_column_values_at_locus(
-            column='exon_id',
-            feature='exon',
+            column="exon_id",
+            feature="exon",
             contig=contig,
             position=position,
             end=end,
@@ -295,8 +295,8 @@ class EnsemblRelease(object):
 
     def transcript_ids_at_locus(self, contig, position, end=None, strand=None):
         return self.db.distinct_column_values_at_locus(
-            column='transcript_id',
-            feature='transcript',
+            column="transcript_id",
+            feature="transcript",
             contig=contig,
             position=position,
             end=end,
@@ -305,8 +305,8 @@ class EnsemblRelease(object):
     def transcript_names_at_locus(
             self, contig, position, end=None, strand=None):
         return self.db.distinct_column_values_at_locus(
-            column='transcript_name',
-            feature='transcript',
+            column="transcript_name",
+            feature="transcript",
             contig=contig,
             position=position,
             end=end,
@@ -314,8 +314,8 @@ class EnsemblRelease(object):
 
     def protein_ids_at_locus(self, contig, position, end=None, strand=None):
         return self.db.distinct_column_values_at_locus(
-            column='protein_id',
-            feature='transcript',
+            column="protein_id",
+            feature="transcript",
             contig=contig,
             position=position,
             end=end,
@@ -334,9 +334,9 @@ class EnsemblRelease(object):
         Given a gene ID returns Locus with: chromosome, start, stop, strand
         """
         return self.db.query_locus(
-            filter_column='gene_id',
+            filter_column="gene_id",
             filter_value=gene_id,
-            feature='gene')
+            feature="gene")
 
     def loci_of_gene_names(self, gene_name):
         """
@@ -345,19 +345,19 @@ class EnsemblRelease(object):
         You can get multiple results since a gene might have multiple copies
         in the genome.
         """
-        return self.db.query_loci('gene_name', gene_name, 'gene')
+        return self.db.query_loci("gene_name", gene_name, "gene")
 
     def locus_of_transcript_id(self, transcript_id):
         return self.db.query_locus(
-            filter_column='transcript_id',
+            filter_column="transcript_id",
             filter_value=transcript_id,
-            feature='transcript')
+            feature="transcript")
 
     def locus_of_exon_id(self, exon_id):
         """
         Given an exon ID returns Locus
         """
-        return self.db.query_locus('exon_id', exon_id, feature='exon')
+        return self.db.query_locus("exon_id", exon_id, feature="exon")
 
     ###################################################
     #
@@ -387,18 +387,18 @@ class EnsemblRelease(object):
         Construct a Gene object for the given gene ID.
         """
         field_names = [
-            'gene_name',
-            'seqname',
-            'start',
-            'end',
-            'strand',
-            'gene_biotype'
+            "gene_name",
+            "seqname",
+            "start",
+            "end",
+            "strand",
+            "gene_biotype"
         ]
         gene_name, contig, start, end, strand, biotype = self.db.query_one(
             field_names,
-            filter_column='gene_id',
+            filter_column="gene_id",
             filter_value=gene_id,
-            feature='gene')
+            feature="gene")
 
         return Gene(
             gene_id=gene_id,
@@ -452,28 +452,28 @@ class EnsemblRelease(object):
         optionally restrict to a chromosome and/or strand.
         """
         return self.all_feature_values(
-            column='gene_name',
-            feature='gene',
+            column="gene_name",
+            feature="gene",
             contig=contig,
             strand=strand)
 
     @memoize
     def gene_name_of_gene_id(self, gene_id):
-        return self._query_gene_name("gene_id", gene_id, 'gene')
+        return self._query_gene_name("gene_id", gene_id, "gene")
 
     @memoize
     def gene_name_of_transcript_id(self, transcript_id):
         return self._query_gene_name(
-            "transcript_id", transcript_id, 'transcript')
+            "transcript_id", transcript_id, "transcript")
 
     @memoize
     def gene_name_of_transcript_name(self, transcript_name):
         return self._query_gene_name(
-            "transcript_name", transcript_name, 'transcript')
+            "transcript_name", transcript_name, "transcript")
 
     @memoize
     def gene_name_of_exon_id(self, exon_id):
-        return self._query_gene_name("exon_id", exon_id, 'exon')
+        return self._query_gene_name("exon_id", exon_id, "exon")
 
     ###################################################
     #
@@ -481,9 +481,9 @@ class EnsemblRelease(object):
     #
     ###################################################
 
-    def _query_gene_ids(self, property_name, value, feature='gene'):
+    def _query_gene_ids(self, property_name, value, feature="gene"):
         results = self.db.query(
-            select_column_names=['gene_id'],
+            select_column_names=["gene_id"],
             filter_column=property_name,
             filter_value=value,
             feature=feature,
@@ -498,8 +498,8 @@ class EnsemblRelease(object):
         (optionally restrict to a given chromosome/contig and/or strand)
         """
         return self.all_feature_values(
-            column='gene_id',
-            feature='gene',
+            column="gene_id",
+            feature="gene",
             contig=contig,
             strand=strand)
 
@@ -509,7 +509,7 @@ class EnsemblRelease(object):
         What are the Ensembl gene IDs associated with a given gene name?
         (due to copy events, there might be multiple genes per name)
         """
-        results = self._query_gene_ids('gene_name', gene_name)
+        results = self._query_gene_ids("gene_name", gene_name)
         if len(results) == 0:
             raise ValueError("Gene name not found: %s" % gene_name)
         return results
@@ -519,8 +519,8 @@ class EnsemblRelease(object):
         """
         What is the Ensembl gene ID associated with a given protein ID?
         """
-        results = self._query_gene_ids('protein_id', protein_id,
-                                       feature='CDS')
+        results = self._query_gene_ids("protein_id", protein_id,
+                                       feature="CDS")
         if len(results) == 0:
             raise ValueError("Protein ID not found: %s" % protein_id)
         assert len(results) == 1, \
@@ -552,22 +552,22 @@ class EnsemblRelease(object):
         """Construct Transcript object with given transcript ID"""
 
         field_names = [
-            'transcript_name',
-            'transcript_biotype',
-            'seqname',
-            'start',
-            'end',
-            'strand',
-            'gene_name',
-            'gene_id',
+            "transcript_name",
+            "transcript_biotype",
+            "seqname",
+            "start",
+            "end",
+            "strand",
+            "gene_name",
+            "gene_id",
         ]
 
         name, biotype, contig, start, end, strand, gene_name, gene_id = \
             self.db.query_one(
                 select_column_names=field_names,
-                filter_column='transcript_id',
+                filter_column="transcript_id",
                 filter_value=transcript_id,
-                feature='transcript',
+                feature="transcript",
                 distinct=True)
 
         return Transcript(
@@ -603,10 +603,10 @@ class EnsemblRelease(object):
 
     def _query_transcript_names(self, property_name, value):
         results = self.db.query(
-            select_column_names=['transcript_name'],
+            select_column_names=["transcript_name"],
             filter_column=property_name,
             filter_value=value,
-            feature='transcript',
+            feature="transcript",
             distinct=True,
             required=True)
         return [result[0] for result in results]
@@ -618,19 +618,19 @@ class EnsemblRelease(object):
         (optionally, restrict to a given chromosome and/or strand)
         """
         return self.all_feature_values(
-            column='transcript_name',
-            feature='transcript',
+            column="transcript_name",
+            feature="transcript",
             contig=contig,
             strand=strand)
 
     @memoize
     def transcript_names_of_gene_name(self, gene_name):
-        return self._query_transcript_names('gene_name', gene_name)
+        return self._query_transcript_names("gene_name", gene_name)
 
     @memoize
     def transcript_name_of_transcript_id(self, transcript_id):
         transcript_names = self._query_transcript_names(
-            'transcript_id', transcript_id)
+            "transcript_id", transcript_id)
         if len(transcript_names) == 0:
             raise ValueError(
                 "No transcript names for transcript ID = %s" % transcript_id)
@@ -645,9 +645,9 @@ class EnsemblRelease(object):
     ###################################################
 
     def _query_transcript_ids(self, property_name, value,
-                              feature='transcript'):
+                              feature="transcript"):
         results = self.db.query(
-            select_column_names=['transcript_id'],
+            select_column_names=["transcript_id"],
             filter_column=property_name,
             filter_value=value,
             feature=feature,
@@ -658,26 +658,26 @@ class EnsemblRelease(object):
     @memoize
     def transcript_ids(self, contig=None, strand=None):
         return self.all_feature_values(
-            column='transcript_id',
-            feature='transcript',
+            column="transcript_id",
+            feature="transcript",
             contig=contig,
             strand=strand)
 
     @memoize
     def transcript_ids_of_gene_id(self, gene_id):
-        return self._query_transcript_ids('gene_id', gene_id)
+        return self._query_transcript_ids("gene_id", gene_id)
 
     @memoize
     def transcript_ids_of_gene_name(self, gene_name):
-        return self._query_transcript_ids('gene_name', gene_name)
+        return self._query_transcript_ids("gene_name", gene_name)
 
     @memoize
     def transcript_ids_of_transcript_name(self, transcript_name):
-        return self._query_transcript_ids('transcript_name', transcript_name)
+        return self._query_transcript_ids("transcript_name", transcript_name)
 
     @memoize
     def transcript_ids_of_exon_id(self, exon_id):
-        return self._query_transcript_ids('exon_id', exon_id)
+        return self._query_transcript_ids("exon_id", exon_id)
 
     @memoize
     def transcript_id_of_protein_id(self, protein_id):
@@ -685,8 +685,8 @@ class EnsemblRelease(object):
         What is the Ensembl transcript ID associated with a given
         protein ID?
         """
-        results = self._query_transcript_ids('protein_id', protein_id,
-                                             feature='CDS')
+        results = self._query_transcript_ids("protein_id", protein_id,
+                                             feature="CDS")
         if len(results) == 0:
             raise ValueError("Protein ID not found: %s" % protein_id)
         assert len(results) == 1, \
@@ -706,7 +706,7 @@ class EnsemblRelease(object):
         Create exon object for all exons in the database, optionally
         restrict to a particular chromosome using the `contig` argument.
         """
-        # DataFrame with single column called 'exon_id'
+        # DataFrame with single column called "exon_id"
         exon_ids = self.exon_ids(contig=contig, strand=strand)
         return [
             self.exon_by_id(exon_id)
@@ -715,23 +715,23 @@ class EnsemblRelease(object):
 
     @memoize
     def exon_by_id(self, exon_id):
-        """Construct an Exon object from its ID by looking up the exon's
+        """Construct an Exon object from its ID by looking up the exon"s
         properties in the given Database.
         """
         field_names = [
-            'seqname',
-            'start',
-            'end',
-            'strand',
-            'gene_name',
-            'gene_id',
+            "seqname",
+            "start",
+            "end",
+            "strand",
+            "gene_name",
+            "gene_id",
         ]
 
         contig, start, end, strand, gene_name, gene_id = self.db.query_one(
             select_column_names=field_names,
-            filter_column='exon_id',
+            filter_column="exon_id",
             filter_value=exon_id,
-            feature='exon',
+            feature="exon",
             distinct=True)
 
         return Exon(
@@ -741,19 +741,7 @@ class EnsemblRelease(object):
             end=end,
             strand=strand,
             gene_name=gene_name,
-            gene_id=gene_id,
-            db=self.db)
-
-    @memoize
-    def exon_by_transcript_id_and_number(self, transcript_id, exon_number):
-        transcript = self.transcript_by_id(transcript_id)
-        if len(transcript.exons) > exon_number:
-            raise ValueError(
-                "Invalid exon number for transcript %s" % transcript_id)
-
-        # exon numbers in Ensembl are 1-based, need to subtract 1 to get
-        # a list index
-        return transcript.exons[exon_number - 1]
+            gene_id=gene_id)
 
     ###################################################
     #
@@ -763,10 +751,10 @@ class EnsemblRelease(object):
 
     def _query_exon_ids(self, property_name, value):
         results = self.db.query(
-            select_column_names=['exon_id'],
+            select_column_names=["exon_id"],
             filter_column=property_name,
             filter_value=value,
-            feature='exon',
+            feature="exon",
             distinct=True,
             required=True)
         return [result[0] for result in results]
@@ -774,23 +762,23 @@ class EnsemblRelease(object):
     @memoize
     def exon_ids(self, contig=None, strand=None):
         return self.all_feature_values(
-            column='exon_id',
-            feature='exon',
+            column="exon_id",
+            feature="exon",
             contig=contig,
             strand=strand)
 
     @memoize
     def exon_ids_of_gene_id(self, gene_id):
-        return self._query_exon_ids('gene_id', gene_id)
+        return self._query_exon_ids("gene_id", gene_id)
 
     @memoize
     def exon_ids_of_gene_name(self, gene_name):
-        return self._query_exon_ids('gene_name', gene_name)
+        return self._query_exon_ids("gene_name", gene_name)
 
     @memoize
     def exon_ids_of_transcript_name(self, transcript_name):
-        return self._query_exon_ids('transcript_name', transcript_name)
+        return self._query_exon_ids("transcript_name", transcript_name)
 
     @memoize
     def exon_ids_of_transcript_id(self, transcript_id):
-        return self._query_exon_ids('transcript_id', transcript_id)
+        return self._query_exon_ids("transcript_id", transcript_id)

--- a/pyensembl/exon.py
+++ b/pyensembl/exon.py
@@ -14,10 +14,6 @@
 
 from __future__ import print_function, division, absolute_import
 
-from typechecks import require_integer
-from memoized_property import memoized_property
-
-from .common import memoize
 from .locus import Locus
 
 class Exon(Locus):
@@ -30,11 +26,9 @@ class Exon(Locus):
             end,
             strand,
             gene_name,
-            gene_id,
-            db):
+            gene_id):
         Locus.__init__(self, contig, start, end, strand)
         self.id = exon_id
-        self.db = db
         self.gene_name = gene_name
         self.gene_id = gene_id
 
@@ -44,104 +38,3 @@ class Exon(Locus):
 
     def __repr__(self):
         return str(self)
-
-    # possible annotations associated with exons
-    _EXON_FEATURES = {'start_codon', 'stop_codon', 'UTR', 'CDS'}
-
-    @memoize
-    def _exon_feature_positions(self, feature):
-        """
-        Find start and end positions of features (such as start codons)
-        which are contained within this exon.
-        """
-        if feature not in self._EXON_FEATURES:
-            raise ValueError("Invalid exon feature: %s" % feature)
-
-        # query for distinct ranges since, for example, multiple transcripts
-        # often have the same start codon. Each transcript's start codon has
-        # its own feature='start_codon' entry
-        query = """
-            SELECT DISTINCT start, end
-            FROM %s
-            WHERE seqname = ?
-            AND strand = ?
-            AND start >= ?
-            AND end <= ?
-        """ % (feature,)
-
-        query_params = [
-            self.contig,
-            self.strand,
-            self.start,
-            self.end,
-        ]
-        cursor = self.db.connection.execute(query, query_params)
-        results = cursor.fetchall()
-
-        # check to make sure we only got back integer values
-        for (start, end) in results:
-            require_integer(start, "start position")
-            require_integer(end, "end position")
-        return results
-
-    @memoized_property
-    def start_codon_positions(self):
-        """
-        Absolute positions of overlapping start codons.
-        """
-        return self._exon_feature_positions('start_codon')
-
-    @memoized_property
-    def stop_codon_positions(self):
-        """
-        Absolute positions of overlapping stop codons.
-        """
-        return self._exon_feature_positions('stop_codon')
-
-    def _first_offset(self, start, end):
-        relative_start, relative_end = self.offset_range(start, end)
-        return min(relative_start, relative_end)
-
-    @memoize
-    def _exon_feature_offsets(self, feature):
-        """
-        Start and end offsets (relative to this exon) of features such as
-        start_codon and stop_codon.
-        """
-        # start and end positions on the chromosome
-        absolute_positions = self._exon_feature_positions(feature)
-        results = []
-        for start, end in absolute_positions:
-            local_position = self._first_offset(start, end)
-            results.append(local_position)
-        return results
-
-    @memoized_property
-    def start_codon_offsets(self):
-        """
-        How many bases from the beginning of the exon (starting from 0)
-        is the first base of the start codon?
-        """
-        return self._exon_feature_offsets('start_codon')
-
-    @memoized_property
-    def stop_codon_offsets(self):
-        """
-        How many bases from the beginning of the exon (starting from 0)
-        is the first base of the stop codon?
-        """
-        return self._exon_feature_offsets('stop_codon')
-
-    @memoized_property
-    def contains_start_codon(self):
-        """
-        Does this exon contain a start codon in any transcript?
-        """
-        return len(self.start_codon_positions) > 0
-
-    @memoized_property
-    def contains_stop_codon(self):
-        """
-        Does this exon contain a stop codon in any transcript?
-        """
-        return len(self.stop_codon_positions) > 0

--- a/pyensembl/exon.py
+++ b/pyensembl/exon.py
@@ -14,48 +14,29 @@
 
 from __future__ import print_function, division, absolute_import
 
-from typechecks import require_integer, require_string
+from typechecks import require_integer
 from memoized_property import memoized_property
 
 from .common import memoize
 from .locus import Locus
 
 class Exon(Locus):
-    def __init__(self, exon_id, db):
-        require_string(exon_id, "exon ID")
 
+    def __init__(
+            self,
+            exon_id,
+            contig,
+            start,
+            end,
+            strand,
+            gene_name,
+            gene_id,
+            db):
+        Locus.__init__(self, contig, start, end, strand)
         self.id = exon_id
         self.db = db
-
-        columns = [
-            'seqname',
-            'start',
-            'end',
-            'strand',
-            'gene_name',
-            'gene_id',
-        ]
-
-        result = self.db.query_one(
-            select_column_names=columns,
-            filter_column='exon_id',
-            filter_value=exon_id,
-            feature='exon',
-            distinct=True)
-
-        result_dict = {}
-        for i, column_name in enumerate(columns):
-            result_dict[column_name] = result[i]
-
-        Locus.__init__(
-            self,
-            result_dict['seqname'],
-            result_dict['start'],
-            result_dict['end'],
-            result_dict['strand'])
-
-        self.gene_name = result_dict['gene_name']
-        self.gene_id = result_dict['gene_id']
+        self.gene_name = gene_name
+        self.gene_id = gene_id
 
     def __str__(self):
         return "Exon(exon_id=%s, gene_name=%s, contig=%s, start=%d, end=%s)" % (

--- a/pyensembl/gene.py
+++ b/pyensembl/gene.py
@@ -15,7 +15,7 @@
 from __future__ import print_function, division, absolute_import
 
 from memoized_property import memoized_property
-from typechecks import require_string, require_instance
+from typechecks import require_instance
 
 from .biotypes import is_valid_biotype
 from .database import Database
@@ -23,8 +23,16 @@ from .locus import Locus
 
 class Gene(Locus):
 
-    def __init__(self, gene_id, ensembl):
-        require_string(gene_id, "gene ID")
+    def __init__(
+            self,
+            gene_id,
+            gene_name,
+            contig,
+            start,
+            end,
+            strand,
+            biotype,
+            ensembl):
         self.id = gene_id
         # can't check the type of ensembl since it will create a circular
         # dependency between this module and ensembl_release but note that
@@ -32,21 +40,7 @@ class Gene(Locus):
         self.ensembl = ensembl
         self.db = ensembl.db
         require_instance(self.db, Database, "db")
-        columns = [
-            'gene_name',
-            'seqname',
-            'start',
-            'end',
-            'strand',
-            'gene_biotype'
-        ]
-        gene_name, contig, start, end, strand, biotype = self.db.query_one(
-            columns,
-            filter_column='gene_id',
-            filter_value=gene_id,
-            feature='gene')
-        if not gene_name:
-            raise ValueError("Missing name for gene with ID = %s" % gene_id)
+
         self.name = gene_name
 
         Locus.__init__(self, contig, start, end, strand)
@@ -55,11 +49,7 @@ class Gene(Locus):
             raise ValueError(
                 "Invalid gene_biotype %s for gene with ID = %s" % (
                     biotype, gene_id))
-        elif biotype:
-            self.biotype = biotype
-        else:
-            raise ValueError(
-                "Missing gene_biotype for gene with ID = %s" % gene_id)
+        self.biotype = biotype
 
     def __str__(self):
         return "Gene(id=%s, name=%s, location=%s:%d-%d)" % (

--- a/pyensembl/gene.py
+++ b/pyensembl/gene.py
@@ -20,7 +20,6 @@ from typechecks import require_string, require_instance
 from .biotypes import is_valid_biotype
 from .database import Database
 from .locus import Locus
-from .transcript import Transcript
 
 class Gene(Locus):
 
@@ -100,15 +99,14 @@ class Gene(Locus):
         # its particular information, might be more efficient if we
         # just get all the columns here, but how do we keep that modular?
         return [
-            Transcript(result[0], self.ensembl)
+            self.ensembl.transcript_by_id(result[0])
             for result in transcript_id_results
         ]
 
     @memoized_property
     def exons(self):
-        exons_dict = {}
+        exon_set = set([])
         for transcript in self.transcripts:
             for exon in transcript.exons:
-                if exon.id not in exons_dict:
-                    exons_dict[exon.id] = exon
-        return list(exons_dict.values())
+                exon_set.add(exon)
+        return list(sorted(exon_set))

--- a/pyensembl/locus.py
+++ b/pyensembl/locus.py
@@ -120,7 +120,13 @@ class Locus(object):
     def length(self):
         return self.end - self.start + 1
 
-    def position_offset(self, position):
+    def offset(self, position):
+        """Offset of given position from stranded start of this locus.
+
+        For example, if a Locus goes from 10..20 and is on the negative strand,
+        then the offset of position 13 is 7, whereas if the Locus is on the
+        positive strand, then the offset is 3.
+        """
         if position > self.end or position < self.start:
             raise ValueError(
                 "Position %d outside valid range %d..%d of %s" % (

--- a/pyensembl/locus.py
+++ b/pyensembl/locus.py
@@ -20,7 +20,7 @@ def normalize_chromosome(c):
     if is_integer(c):
         if c == 0:
             raise ValueError("Contig cannot be 0")
-        c = str(c)
+        return str(c)
 
     require_string(c, "contig name", nonempty=True)
 
@@ -32,13 +32,9 @@ def normalize_chromosome(c):
     # standardize mitochondrial genome to be "MT"
     if c == "M":
         return "MT"
-    # just in case someone is being lazy, capitalize "X" and "Y"
-    elif c == "x":
-        return "X"
-    elif c == "y":
-        return "Y"
     else:
-        return c
+        # just in case someone is being lazy, capitalize "X" and "Y"
+        return c.upper()
 
 def normalize_strand(strand):
     if strand == "+" or strand == "-":

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -15,11 +15,9 @@
 from __future__ import print_function, division, absolute_import
 
 from memoized_property import memoized_property
-from typechecks import require_string, require_instance
 
 from .biotypes import is_valid_biotype
 from .common import memoize
-from .database import Database
 from .locus import Locus
 
 
@@ -28,7 +26,7 @@ class Transcript(Locus):
     Transcript encompasses the locus, exons, and sequence of an Ensembl
     transcript.
 
-    Lazily fetches sequence in case we're constructing many Transcripts
+    Lazily fetches sequence in case we"re constructing many Transcripts
     and not using the sequence, avoid the memory/performance overhead
     of fetching and storing sequences from a FASTA file.
     """
@@ -44,24 +42,16 @@ class Transcript(Locus):
             gene_id,
             gene_name,
             ensembl):
-
-        require_string(transcript_id, "transcript ID")
-
-        self.id = transcript_id
-        self.ensembl = ensembl
-
-        self.db = ensembl.db
-        require_instance(self.db, Database, "db")
-
-        Locus.__init__(self, contig, start, end, strand)
-
-        self.name = transcript_name
-
         if not is_valid_biotype(biotype):
             raise ValueError(
                 "Invalid biotype '%s' for transcript with ID=%s, name=%s" % (
                     biotype, transcript_id, transcript_name))
 
+        Locus.__init__(self, contig, start, end, strand)
+        self.id = transcript_id
+        self.name = transcript_name
+        self.ensembl = ensembl
+        self.db = ensembl.db
         self.biotype = biotype
         self.gene_name = gene_name
         self.gene_id = gene_id
@@ -82,6 +72,7 @@ class Transcript(Locus):
         """
         Length of a transcript is the sum of its exon lengths
         """
+        # return sum(end - start + 1 for (start, end) in self.exon_intervals)
         return sum(len(exon) for exon in self.exons)
 
     def __eq__(self, other):
@@ -95,12 +86,15 @@ class Transcript(Locus):
 
     @memoized_property
     def exons(self):
-        columns = ['exon_number', 'exon_id']
+        # need to look up exon_number alongside ID since each exon may
+        # appear in multiple transcripts and have a different exon number
+        # in each transcript
+        columns = ["exon_number", "exon_id"]
         exon_numbers_and_ids = self.db.query(
             columns,
-            filter_column='transcript_id',
+            filter_column="transcript_id",
             filter_value=self.id,
-            feature='exon')
+            feature="exon")
 
         # fill this list in its correct order (by exon_number) by using
         # the exon_number as a 1-based list offset
@@ -128,7 +122,7 @@ class Transcript(Locus):
         return exons
 
     # possible annotations associated with transcripts
-    _TRANSCRIPT_FEATURES = {'start_codon', 'stop_codon', 'UTR', 'CDS'}
+    _TRANSCRIPT_FEATURES = {"start_codon", "stop_codon", "UTR", "CDS"}
 
     @memoize
     def _transcript_feature_position_ranges(self, feature, required=True):
@@ -140,8 +134,8 @@ class Transcript(Locus):
             raise ValueError("Invalid transcript feature: %s" % feature)
 
         results = self.db.query(
-            select_column_names=['start', 'end'],
-            filter_column='transcript_id',
+            select_column_names=["start", "end"],
+            filter_column="transcript_id",
             filter_value=self.id,
             feature=feature)
 
@@ -178,7 +172,7 @@ class Transcript(Locus):
         Parameters
         ----------
         feature : str
-            Possible values are 'start_codon' or 'stop_codon'
+            Possible values are "start_codon" or "stop_codon"
 
         Returns list of three chromosomal positions.
         """
@@ -197,7 +191,7 @@ class Transcript(Locus):
         Does this transcript have an annotated start_codon entry in Ensembl?
         """
         start_codons = self._transcript_feature_position_ranges(
-            'start_codon', required=False)
+            "start_codon", required=False)
         return len(start_codons) > 0
 
     @memoized_property
@@ -206,7 +200,7 @@ class Transcript(Locus):
         Does this transcript have an annotated stop_codon entry in Ensembl?
         """
         stop_codons = self._transcript_feature_position_ranges(
-            'stop_codon', required=False)
+            "stop_codon", required=False)
         return len(stop_codons) > 0
 
     @memoized_property
@@ -214,19 +208,35 @@ class Transcript(Locus):
         """
         Chromosomal positions of nucleotides in start codon.
         """
-        return self._codon_positions('start_codon')
+        return self._codon_positions("start_codon")
 
     @memoized_property
     def stop_codon_positions(self):
         """
         Chromosomal positions of nucleotides in stop codon.
         """
-        return self._codon_positions('stop_codon')
+        return self._codon_positions("stop_codon")
+
+    @memoized_property
+    def exon_intervals(self):
+        """List of (start,end) tuples for each exon of this transcript,
+        in the order specified by the 'exon_number' column of the Ensembl
+        exon table.
+        """
+        results = self.db.query(
+            select_column_names=["exon_number", "start", "end"],
+            filter_column="transcript_id",
+            filter_value=self.id,
+            feature="exon")
+        sorted_intervals = [None] * len(results)
+        for (exon_number, start, end) in results:
+            sorted_intervals[int(exon_number) - 1] = (start, end)
+        return sorted_intervals
 
     def spliced_offset(self, position):
         """
         Convert from an absolute chromosomal position to the offset into
-        this transcript's spliced mRNA.
+        this transcript"s spliced mRNA.
 
         Position must be inside some exon (otherwise raise exception).
         """
@@ -235,6 +245,7 @@ class Transcript(Locus):
         assert type(position) == int, \
             "Position argument must be an integer, got %s : %s" % (
                 position, type(position))
+
         if position < self.start or position > self.end:
             raise ValueError(
                 "Invalid position: %d (must be between %d and %d)" % (
@@ -255,15 +266,15 @@ class Transcript(Locus):
         # Exon Name:                exon 1                exon 2
         # Spliced Offset:           123456                789...
         # Intron vs. Exon: ...iiiiiieeeeeeiiiiiiiiiiiiiiiieeeeeeiiiiiiiiiii...
+        # for (exon_start_position, exon_end_position) in self.exon_intervals:
         for exon in self.exons:
             exon_unspliced_start, exon_unspliced_end = self.offset_range(
                 exon.start, exon.end)
-
             # If the relative position is not within this exon, keep a running
             # total of the total exonic length-so-far.
             #
             # Otherwise, if the relative position is within an exon, get its
-            # offset into that exon by subtracting the exon's relative start
+            # offset into that exon by subtracting the exon"s relative start
             # position from the relative position. Add that to the total exonic
             # length-so-far.
             if exon_unspliced_start <= unspliced_offset <= exon_unspliced_end:
@@ -272,7 +283,8 @@ class Transcript(Locus):
                 exon_offset = unspliced_offset - exon_unspliced_start
                 return total_spliced_offset + exon_offset
             else:
-                total_spliced_offset += len(exon)
+                exon_length = len(exon)  # exon_end_position - exon_start_position + 1
+                total_spliced_offset += exon_length
         raise ValueError(
             "Couldn't find position %d on any exon of %s" % (
                 position, self.id))
@@ -344,7 +356,7 @@ class Transcript(Locus):
         Return absolute chromosome position ranges for CDS fragments
         of this transcript
         """
-        return self._transcript_feature_position_ranges('CDS')
+        return self._transcript_feature_position_ranges("CDS")
 
     @memoized_property
     def complete(self):
@@ -363,7 +375,7 @@ class Transcript(Locus):
     def sequence(self):
         """
         Spliced cDNA sequence of transcript
-        (includes 5' UTR, coding sequence, and 3' UTR)
+        (includes 5" UTR, coding sequence, and 3" UTR)
         """
         return self.ensembl.transcript_sequences.get(self.id)
 

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -72,7 +72,6 @@ class Transcript(Locus):
         """
         Length of a transcript is the sum of its exon lengths
         """
-        # return sum(end - start + 1 for (start, end) in self.exon_intervals)
         return sum(len(exon) for exon in self.exons)
 
     def __eq__(self, other):
@@ -266,7 +265,6 @@ class Transcript(Locus):
         # Exon Name:                exon 1                exon 2
         # Spliced Offset:           123456                789...
         # Intron vs. Exon: ...iiiiiieeeeeeiiiiiiiiiiiiiiiieeeeeeiiiiiiiiiii...
-        # for (exon_start_position, exon_end_position) in self.exon_intervals:
         for exon in self.exons:
             exon_unspliced_start, exon_unspliced_end = self.offset_range(
                 exon.start, exon.end)

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -20,7 +20,6 @@ from typechecks import require_string, require_instance
 from .biotypes import is_valid_biotype
 from .common import memoize
 from .database import Database
-from .exon import Exon
 from .locus import Locus
 
 
@@ -143,7 +142,7 @@ class Transcript(Locus):
         exons = [None] * len(results)
 
         for exon_number, exon_id in results:
-            exon = Exon(exon_id, self.db)
+            exon = self.ensembl.exon_by_id(exon_id)
             exon_number = int(exon_number)
             assert exon_number >= 1, "Invalid exon number: %s" % exon_number
             assert exon_number <= len(exons), \

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError as e:
 if __name__ == '__main__':
     setup(
         name='pyensembl',
-        version="0.6.3",
+        version="0.6.4",
         description="Python interface to ensembl reference genome metadata",
         author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",

--- a/test/test_exon_object.py
+++ b/test/test_exon_object.py
@@ -7,39 +7,39 @@ from __future__ import absolute_import
 
 from pyensembl import EnsemblRelease
 
-ensembl77 = EnsemblRelease(77, auto_download=True)
+ensembl = EnsemblRelease(79, auto_download=True)
 
 def test_exon_object_by_id():
     """
     test_exon_object_by_id : check properties of exon 4 of CTNNB1 when looked
     up by ID in Ensembl 77.
     """
-    exon = ensembl77.exon_by_id("ENSE00003464041")
+    exon = ensembl.exon_by_id("ENSE00003464041")
     assert exon.gene_name == "CTNNB1", \
         "Unexpected gene name: %s" % exon.gene_name
     assert exon.contig == "3", exon.contig
     assert exon.strand == "+"
     assert exon.on_forward_strand
     assert exon.on_positive_strand
-    assert exon.start ==  41224526, "Unexpected exon start: %s" % exon.start
+    assert exon.start == 41224526, "Unexpected exon start: %s" % exon.start
     assert exon.end == 41224753, "Unexpected exon end: %s" % exon.end
-    assert exon.length ==  228
+    assert exon.length == len(exon) == 228
 
 def test_exon_object_by_id_on_negative_strand():
     """
     test_exon_object_by_id : check properties of exon 1 from CXCR3 when looked
     up by ID in Ensembl 77.
     """
-    exon = ensembl77.exon_by_id("ENSE00001817013")
+    exon = ensembl.exon_by_id("ENSE00001817013")
     assert exon.gene_name == "CXCR3", \
         "Unexpected gene name: %s" % exon.gene_name
     assert exon.contig == "X", exon.contig
     assert exon.strand == "-"
     assert exon.on_backward_strand
     assert exon.on_negative_strand
-    assert exon.start ==  71618438, "Unexpected exon start: %s" % exon.start
+    assert exon.start == 71618438, "Unexpected exon start: %s" % exon.start
     assert exon.end == 71618517, "Unexpected exon end: %s" % exon.end
-    assert exon.length ==  80
+    assert exon.length == len(exon) == 80
 
 
 def test_exon_object_at_locus():
@@ -47,14 +47,14 @@ def test_exon_object_at_locus():
     test_exon_object_at_locus : check properties of exon 4 of CTNNB1 when looked
     up by its location on the forward strand of chr3
     """
-    exons = ensembl77.exons_at_locus(3, 41224526, strand="+")
+    exons = ensembl.exons_at_locus(3, 41224526, strand="+")
     for exon in exons:
         assert exon.gene_name == "CTNNB1", exon.transcript_name
         assert exon.contig == "3", exon.contig
         assert exon.strand == "+"
         assert exon.on_forward_strand
         assert exon.on_positive_strand
-        assert exon.start <=  41224526, "Unexpected exon start: %s" % exon.start
+        assert exon.start <= 41224526, "Unexpected exon start: %s" % exon.start
         assert exon.end >= 41224526, "Unexpected exon end: %s" % exon.end
 
 def test_exon_object_at_locus_on_negative_strand():
@@ -62,80 +62,12 @@ def test_exon_object_at_locus_on_negative_strand():
     test_exon_object_at_locus : check properties of exon 1 of CXCR3 when looked
     up by its location on the negative strand of chrX
     """
-    exons = ensembl77.exons_at_locus("chrX", 71618517, strand="-")
+    exons = ensembl.exons_at_locus("chrX", 71618517, strand="-")
     for exon in exons:
         assert exon.gene_name == "CXCR3", exon.transcript_name
         assert exon.contig == "X", exon.contig
         assert exon.strand == "-"
         assert exon.on_backward_strand
         assert exon.on_negative_strand
-        assert exon.start <=  71618517, "Unexpected exon start: %s" % exon.start
+        assert exon.start <= 71618517, "Unexpected exon start: %s" % exon.start
         assert exon.end >= 71618517, "Unexpected exon end: %s" % exon.end
-
-
-def test_contains_start_codon():
-    """
-    test_contains_start_codon : Test that first exon of CXCR3-002 contains
-    a start codon.
-    """
-    transcript = ensembl77.transcripts_by_name("CXCR3-002")[0]
-    exon = transcript.exons[0]
-    assert exon.contains_start_codon
-
-def test_contains_stop_codon():
-    """
-    Test that second exon of CXCR3-002 contains a stop codon.
-    """
-    transcript = ensembl77.transcripts_by_name("CXCR3-002")[0]
-    exon = transcript.exons[1]
-    assert exon.contains_stop_codon
-
-def test_partial_start_codons():
-    """
-    test_partial_start_codons : Make sure none of the start codons returned
-    only partially overlap with an exon.
-    """
-    # Exon ENSE00003718948 has a start codon immediately before the
-    # exon's start position on the forward strand
-    exon = ensembl77.exon_by_id("ENSE00003718948")
-    for (start, end) in exon.start_codon_positions:
-        assert start >= exon.start, \
-            "Exon at locus [%d, %d], start codon at %d" % (
-                exon.start, exon.end, start)
-
-    for offset in exon.start_codon_offsets:
-        assert offset >= 0, \
-            "Invalid negative offset for start codon: %d" % offset
-        assert offset != 0, \
-            "Partially overlapping start codon should not be included"
-
-def test_start_codon_offset():
-    """
-    test_start_codon_offset : Ensure that start codon in exon #1 of CXCR3-002
-    is 68 nucleotides from the start of the exon.
-    """
-    transcript = ensembl77.transcripts_by_name("CXCR3-002")[0]
-    exon = transcript.exons[0]
-    start_offsets = exon.start_codon_offsets
-    assert len(start_offsets) == 1, \
-        "First exon of CXCR3-002 should only overlap one start codon"
-    offset = start_offsets[0]
-    assert offset == 68, \
-        "Expected stop codon 68nt from start of exon #1, got %s" % (offset,)
-
-def test_stop_codon_offset():
-    """
-    test_stop_codon_offset : Ensure that the only stop codon
-    overlapping exon #2 of CXCR-002 is 1092 nucleotides
-    from the start of the exon.
-    """
-    transcript = ensembl77.transcripts_by_name("CXCR3-002")[0]
-    exon = transcript.exons[1]
-    stop_offsets = exon.stop_codon_offsets
-    assert len(stop_offsets) == 1, \
-        "Last exon of CXCR3-002 should only overlap one stop codon, got: %s" % (
-        stop_offsets)
-    offset = stop_offsets[0]
-    assert offset == 1092, \
-        "Expected stop codon 1092nt from start of exon #2, got %s" % (offset,)
-

--- a/test/test_gene_objects.py
+++ b/test/test_gene_objects.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from pyensembl import Gene
-
 from .test_common import test_ensembl_releases
 from .data import TP53_gene_id
 
@@ -30,8 +28,8 @@ def test_TP53_gene_object_by_name(ensembl):
 @test_ensembl_releases()
 def test_equal_genes(ensembl):
     gene1 = ensembl.genes_by_name("TP53")[0]
-    # make an identical gene
-    gene2 = Gene(gene1.id, ensembl)
+    # get an identical gene
+    gene2 = ensembl.gene_by_id(gene1.id)
 
     assert hash(gene1) == hash(gene2)
     assert gene1 == gene2

--- a/test/test_locus.py
+++ b/test/test_locus.py
@@ -79,32 +79,32 @@ def test_locus_contains():
 
 def test_position_offset():
     forward_locus = Locus("1", 10, 20, "+")
-    assert forward_locus.position_offset(10) == 0
-    assert forward_locus.position_offset(15) == 5
-    assert forward_locus.position_offset(19) == 9
-    assert forward_locus.position_offset(20) == 10
+    assert forward_locus.offset(10) == 0
+    assert forward_locus.offset(15) == 5
+    assert forward_locus.offset(19) == 9
+    assert forward_locus.offset(20) == 10
 
     negative_locus = Locus("1", 10, 20, "-")
-    assert negative_locus.position_offset(10) == 10
-    assert negative_locus.position_offset(15) == 5
-    assert negative_locus.position_offset(19) == 1
-    assert negative_locus.position_offset(20) == 0
+    assert negative_locus.offset(10) == 10
+    assert negative_locus.offset(15) == 5
+    assert negative_locus.offset(19) == 1
+    assert negative_locus.offset(20) == 0
 
     # don't allow negative offsets
     with assert_raises(ValueError, None):
-        forward_locus.position_offset(9)
+        forward_locus.offset(9)
 
     # don't allow negative offsets
     with assert_raises(ValueError, None):
-        negative_locus.position_offset(9)
+        negative_locus.offset(9)
 
     # don't allow offset past the end of the locus
     with assert_raises(ValueError, None):
-        forward_locus.position_offset(21)
+        forward_locus.offset(21)
 
     # don't allow offset past the end of the locus
     with assert_raises(ValueError, None):
-        negative_locus.position_offset(21)
+        negative_locus.offset(21)
 
 
 def test_range_offset():
@@ -148,4 +148,3 @@ def test_locus_distance():
     inf = float("inf")
     assert locus_chr1_10_20_pos.distance_to_locus(locus_chr2_21_25_pos) == inf
     assert locus_chr1_10_20_pos.distance_to_locus(locus_chr1_21_25_neg) == inf
-

--- a/test/test_transcript_objects.py
+++ b/test/test_transcript_objects.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from pyensembl import Locus, Transcript
+from pyensembl import Locus
 from nose.tools import eq_, assert_not_equal, assert_greater
 
 from .test_common import ensembl_grch38, test_ensembl_releases
@@ -150,8 +150,8 @@ def test_transcript_cds_CTNNIP1_004():
 @test_ensembl_releases()
 def test_equal_transcripts(ensembl):
     t1 = ensembl.transcripts_by_name("TP53-001")[0]
-    # make an identical gene
-    t2 = Transcript(t1.id, ensembl)
+    # get an identical gene
+    t2 = ensembl.transcript_by_id(t1.id)
     eq_(t1, t2)
     eq_(hash(t1), hash(t2))
 


### PR DESCRIPTION
Make sure we never construct the same `Transcript` or `Exon` object twice by routing through `EnsemblRelease.exon_by_id` and `EnsemblRelease.transcript_by_id`. This not only cuts down on the cost of initialization but makes sure we don't recompute cached properties.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pyensembl/84)
<!-- Reviewable:end -->
