### PR TITLE
Update deprecated skbio functionality to newer equivalnets

### DIFF
--- a/pyensembl/common.py
+++ b/pyensembl/common.py
@@ -22,11 +22,11 @@ from typechecks import is_string
 def dump_pickle(obj, filepath):
     with open(filepath, "wb") as f:
         # use lower protocol for compatibility between Python 2 and Python 3
-        pickle.dump(obj, file=f, protocol=2, fix_imports=True)
+        pickle.dump(obj, file=f, protocol=2)
 
 def load_pickle(filepath):
     with open(filepath, "rb") as f:
-        obj = pickle.load(f, fix_imports=True)
+        obj = pickle.load(f)
     return obj
 
 def _memoize_cache_key(args, kwargs):

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError as e:
 if __name__ == '__main__':
     setup(
         name='pyensembl',
-        version="0.8.0",
+        version="0.8.1",
         description="Python interface to ensembl reference genome metadata",
         author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",

--- a/test/test_sequence_data.py
+++ b/test/test_sequence_data.py
@@ -9,7 +9,7 @@ import tempfile
 from nose.tools import assert_raises
 from pyensembl import SequenceData
 
-from skbio import DNASequence
+from skbio import DNA
 from .data import data_path
 
 FASTA_PATH = data_path("mouse.ensembl.81.partial.ENSMUSG00000017167.fa")
@@ -18,10 +18,10 @@ def test_sequence_type():
     with tempfile.TemporaryDirectory() as tmpdir:
         seqs_dna = SequenceData(
             FASTA_PATH,
-            sequence_type=DNASequence,
+            sequence_type=DNA,
             cache_directory_path=tmpdir)
         seq = seqs_dna.get("ENSMUST00000138942")
-        assert isinstance(seq, DNASequence)
+        assert isinstance(seq, DNA)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         seqs_str = SequenceData(

--- a/test/test_transcript_sequences.py
+++ b/test/test_transcript_sequences.py
@@ -22,17 +22,3 @@ def test_transcript_sequence_ensembl54():
     ]
     full_transcript_sequence = "".join(nucleotide_lines)
     eq_(str(seq), full_transcript_sequence)
-
-    # make sure the Sequence object's reverse and complement properties work
-    reverse_complement = seq.complement()
-    reverse_complement_lines = [
-        "GAAAAACATTATTTTTTTATGCTGAAAAGATACACATATATTTAGAGTTAGCCAGCTGGACTCAGTTTA",
-        "GGTGATCCCAATTTTGTTACAACATCGAAAGCATCATAATCAGGAGCAAGTCGAACATATGCCTTGTTC",
-        "TCTTTATCAGGACAAATCAGGGTGGTGACCTTGGCCACATCACTGTCATAGAGCTTCTTCACAGCCTGT",
-        "CTGATCTGGTGCTTGTTGGCTTTAACATCCACAGTGAACACAAGCGTGTTGTTTTCTTCTATCTTCTTC",
-        "ACGGCCGACTCAGTGGTCAGCGGAAACTTGATGATAGCATAGTGGCCAAGCTTGTTTCTCCTGGGGGTG",
-        "CTCTTCCGAGGATATCTGGGCTGCCTCCGGAGTCGCAGTGTCTTGGGCCGCCTGAAGGTGGGTGACATG"
-    ]
-    reverse_complement = "".join(reverse_complement_lines)
-    eq_(len(seq.reverse_complement()), 414)
-    eq_(str(seq.reverse_complement()), reverse_complement)


### PR DESCRIPTION
* `skbio.parse_fasta` is deprecated (and seems to be missing entirely from the latest pip version), using `skbio.read`

* Similarly, using `skbio.DNA` instead of `skbio.DNASequence`

* Got rid of expectation that sequences returned by `SequenceData` should have `complement()` method (still undecided whether these should be `str` or `skbio.Sequence` objects, Varcode wants to concatenate sequences which skbio doesn't support)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pyensembl/117)
<!-- Reviewable:end -->
