### PR TITLE
Override cache dir if PYENSEMBL_CACHE_DIR is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ human reference data from Ensembl releases 75 and 76.
 Alternatively, you can create the `EnsemblRelease` object from inside a Python
 process and call `ensembl_object.download()` followed by `ensembl_object.index()`.
 
+## Cache Location
+By default, PyEnsembl uses the platform-specific `Cache` folder
+and caches the files into the `pyensembl` sub-directory.
+You can override this default by setting the environment key `PYENSEMBL_CACHE_DIR`
+as your preferred location for caching:
+
+```sh
+export PYENSEMBL_CACHE_DIR=/custom/cache/dir
+```
+
+or
+
+```python
+import os
+
+os.environ['PYENSEMBL_CACHE_DIR'] = '/custom/cache/dir'
+# ... PyEnsembl API usage
+```
+
 # Non-Ensembl Data
 
 PyEnsembl also allows arbitrary genomes via the specification

--- a/pyensembl/download_cache.py
+++ b/pyensembl/download_cache.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os import listdir, remove
+from os import listdir, remove, environ
 from os.path import join, exists, split, abspath
 from shutil import copy2, rmtree
 import logging
@@ -20,6 +20,7 @@ import logging
 import datacache
 
 CACHE_BASE_SUBDIR = "pyensembl"
+CACHE_DIR_ENV_KEY = "PYENSEMBL_CACHE_DIR"
 
 def cache_subdirectory(
         reference_name=None,
@@ -111,8 +112,10 @@ class DownloadCache(object):
                 annotation_name=annotation_name,
                 annotation_version=annotation_version)
 
+            # If `CACHE_DIR_ENV_KEY` is set, the cache will be saved there
             self._cache_directory_path = datacache.get_data_dir(
-                subdir=self.cache_subdirectory)
+                subdir=self.cache_subdirectory,
+                envkey=CACHE_DIR_ENV_KEY)
 
         self.decompress_on_download = decompress_on_download
         self.copy_local_files_to_cache = copy_local_files_to_cache

--- a/test/test_download_cache.py
+++ b/test/test_download_cache.py
@@ -1,11 +1,16 @@
 from __future__ import absolute_import
 
-from nose.tools import assert_raises
+from nose.tools import assert_raises, ok_
 from pyensembl.download_cache import (
     DownloadCache,
     MissingLocalFile,
     MissingRemoteFile
 )
+
+import os
+import tempfile
+
+from .data import data_path
 
 download_cache = DownloadCache(
     reference_name="__test_reference",
@@ -25,3 +30,21 @@ def test_download_cache_missing_remote_file():
     with assert_raises(MissingRemoteFile):
         download_cache.download_or_copy_if_necessary(
             path_or_url="ftp://NOTAURL.NOTAURL.NOTAURL")
+
+def test_download_cache_custom_location():
+    test_file = "refseq.ucsc.small.gtf"
+    tmp_dir = os.path.join(tempfile.gettempdir(), "pyensembl")
+    os.environ['PYENSEMBL_CACHE_DIR'] = tmp_dir
+    # We need another instance of DownloadCache
+    # that copies files over to cache folder
+    download_cache = DownloadCache(
+        reference_name="test",
+        annotation_name="test",
+        copy_local_files_to_cache=True)
+    # clean up
+    download_cache.delete_cache_directory()
+    download_cache.download_or_copy_if_necessary(
+        download_if_missing=True,
+        path_or_url=data_path(test_file))
+    ok_(os.path.exists(os.path.join(tmp_dir, test_file)))
+    del os.environ['PYENSEMBL_CACHE_DIR']


### PR DESCRIPTION
so that we can write the cache to a shared directory when running analyses on multi-node clusters.

Context: https://github.com/hammerlab/biokepi/pull/268

cc: @arahuja and @seb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pyensembl/156)
<!-- Reviewable:end -->
