### PR TITLE
Deserialization should construct cached EnsemblRelease objects

### DIFF
--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -43,7 +43,7 @@ def cached_release(release, species="human"):
     otherwise returns the old instance.
 
     Keeping this function for backwards compatibility but this functionality
-    has been moving onto the EnsemblRelease object itself by overriding __new__.
+    has been moving into the cached method of EnsemblRelease.
     """
     return EnsemblRelease.cached(release=release, species=species)
 

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -35,7 +35,7 @@ from .species import (
 )
 from .transcript import Transcript
 
-__version__ = '0.9.6'
+__version__ = '0.9.7'
 
 def cached_release(release, species="human"):
     """

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -17,7 +17,7 @@ from __future__ import print_function, division, absolute_import
 from .memory_cache import MemoryCache
 from .download_cache import DownloadCache
 from .ensembl_release import EnsemblRelease
-from .ensembl_release_versions import check_release_number, MAX_ENSEMBL_RELEASE
+from .ensembl_release_versions import MAX_ENSEMBL_RELEASE
 from .exon import Exon
 from .genome import Genome
 from .gene import Gene
@@ -37,26 +37,21 @@ from .transcript import Transcript
 
 __version__ = '0.9.6'
 
-_cache = {}
-
-def cached_release(version, species="human"):
-    """Cached construction of EnsemblRelease objects. It's desirable to reuse
-    the same EnsemblRelease object since each one will store a lot of cached
-    annotation data in-memory.
+def cached_release(release, species="human"):
     """
-    version = check_release_number(version)
-    species = check_species_object(species)
-    key = (version, species)
-    if key not in _cache:
-        ensembl = EnsemblRelease(version, species=species)
-        _cache[key] = ensembl
-    return _cache[key]
+    Create an EnsemblRelease instance only if it's hasn't already been made,
+    otherwise returns the old instance.
+
+    Keeping this function for backwards compatibility but this functionality
+    has been moving onto the EnsemblRelease object itself by overriding __new__.
+    """
+    return EnsemblRelease.cached(release=release, species=species)
 
 def genome_for_reference_name(reference_name):
     reference_name = normalize_reference_name(reference_name)
     species = find_species_by_reference(reference_name)
     (_, max_ensembl_release) = species.reference_assemblies[reference_name]
-    return cached_release(max_ensembl_release, species=species)
+    return cached_release(release=max_ensembl_release, species=species)
 
 ensembl_grch36 = ensembl54 = cached_release(54)  # last release for GRCh36/hg18
 ensembl_grch37 = ensembl75 = cached_release(75)  # last release for GRCh37/hg19

--- a/pyensembl/ensembl_release.py
+++ b/pyensembl/ensembl_release.py
@@ -74,13 +74,12 @@ class EnsemblRelease(Genome):
             server=ENSEMBL_FTP_SERVER):
         self.release, self.species, self.server = self.normalize_init_values(
             release=release, species=species, server=server)
-        self.species = species
-        self.server = server
 
         self.gtf_url = make_gtf_url(
             ensembl_release=self.release,
-            species=species,
-            server=server)
+            species=self.species,
+            server=self.server)
+
         self.transcript_fasta_url = make_fasta_url(
             ensembl_release=self.release,
             species=self.species.latin_name,
@@ -90,7 +89,7 @@ class EnsemblRelease(Genome):
             ensembl_release=self.release,
             species=self.species.latin_name,
             sequence_type="pep",
-            server=server)
+            server=self.server)
 
         self.reference_name = self.species.which_reference(self.release)
 

--- a/pyensembl/ensembl_release.py
+++ b/pyensembl/ensembl_release.py
@@ -44,6 +44,10 @@ class EnsemblRelease(Genome):
         species = check_species_object(species)
         return (release, species, server)
 
+    # Using a WeakValueDictionary instead of an ordinary dict to prevent a
+    # memory leak in cases where we test many different releases in sequence.
+    # When all the references to a particular EnsemblRelease die then that
+    # genome should also be removed from this cache.
     _genome_cache = WeakValueDictionary()
 
     @classmethod

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -25,7 +25,6 @@ from .data import (
     setup_init_custom_mouse_genome
 )
 
-
 @test_ensembl_releases()
 def test_pickle_ensembl_gene(ensembl_genome):
     gene = ensembl_genome.gene_by_id(TP53_gene_id)
@@ -112,3 +111,10 @@ def test_species_to_json():
 
 def test_species_to_pickle():
     eq_(human, pickle.loads(pickle.dumps(human)))
+
+
+@test_ensembl_releases()
+def test_unique_memory_address_of_unpickled_genomes(ensembl_genome):
+    unpickled = pickle.loads(pickle.dumps(ensembl_genome))
+    assert ensembl_genome is unpickled, \
+        "Expected same object for %s but got two different instances" % (unpickled,)


### PR DESCRIPTION
* Moved contents of `cached_release` onto the EnsemblRelease object (`EnsemblRelease.cached`)
* Using `WeakValueDictionary` instead of ordinary dict to avoid memory leak
* Added `from_dict` class method to use `cached` for deserialization

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pyensembl/163)
<!-- Reviewable:end -->
